### PR TITLE
Fix LD_LIBRARY_PATH on nix so spin can run!

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,12 @@
             ];
 
             shellHook = ''
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+                pkgs.stdenv.cc.cc
+                openssl
+              ]}
             '';
+
             RUST_SRC_PATH = "${rustTarget}/lib/rustlib/src/rust/library";
           };
         }


### PR DESCRIPTION
Fixes the issue where spin can't find the std c++ runtime

```
     Running `target/debug/spin`
target/debug/spin: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```