### PR TITLE
Hardcode rust version to 1.79 with compiles the code and passes all test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,21 @@
   "nodes": {
     "fenix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs",
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1716877613,
-        "narHash": "sha256-GOCKwLphClUGKw0gFDZZmF2UM3vLLLnWrFbAH2AINCI=",
+        "lastModified": 1710742993,
+        "narHash": "sha256-W0PQCe0bW3hKF5lHawXrKynBcdSP18Qa4sb8DcUfOqI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "08ea8011dd25421c104a5f44d16a713a27d93fde",
+        "rev": "6f2fec850f569d61562d3a47dc263f19e9c7d825",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
+        "rev": "6f2fec850f569d61562d3a47dc263f19e9c7d825",
         "type": "github"
       }
     },
@@ -59,6 +58,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1703013332,
         "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
@@ -73,7 +88,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -93,7 +108,7 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -117,7 +132,7 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1703124916,

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/fenix?rev=6f2fec850f569d61562d3a47dc263f19e9c7d825";
+      #inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 


### PR DESCRIPTION
Fix rust tool chain version to 1.79-nightly used by nix

`cargo test` crashes rust compiler with latest nightly 1.80

```
thread 'rustc' panicked at compiler/rustc_codegen_ssa/src/back/link.rs:2700:27:
index out of bounds: the len is 652 but the index is 652
stack backtrace:
   0:     0x7f8cb8985155 - std::backtrace_rs::backtrace::libunwind::trace::h2e84716758cca558
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/../../backtrace/src/backtrace/libunwind.rs:105:5
   1:     0x7f8cb8985155 - std::backtrace_rs::backtrace::trace_unsynchronized::hb3ed557fca7242cc
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7f8cb8985155 - std::sys_common::backtrace::_print_fmt::hb0f10f91238a0096
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys_common/backtrace.rs:68:5
   3:     0x7f8cb8985155 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h852f5b172565b456
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7f8cb89d435b - core::fmt::rt::Argument::fmt::hd416313f4ba36756
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/core/src/fmt/rt.rs:165:63
   5:     0x7f8cb89d435b - core::fmt::write::h0fe66311516c17da
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/core/src/fmt/mod.rs:1168:21
   6:     0x7f8cb8979edf - std::io::Write::write_fmt::had3091ab7db0ae31
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/io/mod.rs:1835:15
   7:     0x7f8cb8984f2e - std::sys_common::backtrace::_print::hc0dd4fd46c6c496b
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x7f8cb8984f2e - std::sys_common::backtrace::print::h1bf67ced2e688658
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x7f8cb8987959 - std::panicking::default_hook::{{closure}}::h1ecb85d4a200d366
  10:     0x7f8cb89876fa - std::panicking::default_hook::h36cf8995acb7e516
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/panicking.rs:298:9
  11:     0x7f8cb51712ff - std[d95a2c7d06309c9c]::panicking::update_hook::<alloc[4f333868965f9f2f]::boxed::Box<rustc_driver_impl[639cf1cd1f0d24bb]::install_ice_hook::{closure#0}>>::{closure#0}
  12:     0x7f8cb898808b - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h706bc9e55d581e3a
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/alloc/src/boxed.rs:2077:9
  13:     0x7f8cb898808b - std::panicking::rust_panic_with_hook::h632bd0ea3dc19d0a
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/panicking.rs:799:13
  14:     0x7f8cb8987e04 - std::panicking::begin_panic_handler::{{closure}}::hd420ffa4c99569f8
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/panicking.rs:664:13
  15:     0x7f8cb8985619 - std::sys_common::backtrace::__rust_end_short_backtrace::h71b0be4d0a4a1270
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys_common/backtrace.rs:171:18
  16:     0x7f8cb8987b37 - rust_begin_unwind
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/panicking.rs:652:5
  17:     0x7f8cb89d08f3 - core::panicking::panic_fmt::h35d62e7c1359f628
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/core/src/panicking.rs:72:14
  18:     0x7f8cb89d0b07 - core::panicking::panic_bounds_check::hb36eb1a4243efd44
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/core/src/panicking.rs:274:5
  19:     0x7f8cb73a580e - rustc_codegen_ssa[504a5cc3414ab869]::back::link::linker_with_args
  20:     0x7f8cb739a05e - rustc_codegen_ssa[504a5cc3414ab869]::back::link::link_natively
  21:     0x7f8cb758938f - rustc_codegen_ssa[504a5cc3414ab869]::back::link::link_binary
  22:     0x7f8cb75888a2 - <rustc_codegen_llvm[828db0275b49fd21]::LlvmCodegenBackend as rustc_codegen_ssa[504a5cc3414ab869]::traits::backend::CodegenBackend>::link
  23:     0x7f8cb7029ca4 - <rustc_interface[95b5883725526a6a]::queries::Linker>::link
  24:     0x7f8cb717e069 - rustc_interface[95b5883725526a6a]::interface::run_compiler::<core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>, rustc_driver_impl[639cf1cd1f0d24bb]::run_compiler::{closure#0}>::{closure#1}
  25:     0x7f8cb7169ae7 - std[d95a2c7d06309c9c]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[95b5883725526a6a]::util::run_in_thread_with_globals<rustc_interface[95b5883725526a6a]::util::run_in_thread_pool_with_globals<rustc_interface[95b5883725526a6a]::interface::run_compiler<core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>, rustc_driver_impl[639cf1cd1f0d24bb]::run_compiler::{closure#0}>::{closure#1}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>::{closure#0}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>
  26:     0x7f8cb71698aa - <<std[d95a2c7d06309c9c]::thread::Builder>::spawn_unchecked_<rustc_interface[95b5883725526a6a]::util::run_in_thread_with_globals<rustc_interface[95b5883725526a6a]::util::run_in_thread_pool_with_globals<rustc_interface[95b5883725526a6a]::interface::run_compiler<core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>, rustc_driver_impl[639cf1cd1f0d24bb]::run_compiler::{closure#0}>::{closure#1}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>::{closure#0}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[d48e893a67888ba4]::result::Result<(), rustc_span[6897b8fb942bba37]::ErrorGuaranteed>>::{closure#2} as core[d48e893a67888ba4]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  27:     0x7f8cb8991eeb - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h3e75214001d556a9
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/alloc/src/boxed.rs:2063:9
  28:     0x7f8cb8991eeb - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h20b9dbfb989fe76c
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/alloc/src/boxed.rs:2063:9
  29:     0x7f8cb8991eeb - std::sys::pal::unix::thread::Thread::new::thread_start::h7c7dbdc729c9eeaa
                               at /rustc/84b40fc908c3adc7e0e470b3fbaa264df0e122b8/library/std/src/sys/pal/unix/thread.rs:108:17
  30:     0x7f8cb1ea3084 - start_thread
  31:     0x7f8cb1f2560c - __GI___clone3
  32:                0x0 - <unknown>

error: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: please make sure that you have updated to the latest nightly

note: please attach the file at `/home/adikov/code/repos/spin/rustc-ice-2024-06-24T12_54_14-1469521.txt` to your bug report

note: compiler flags: -C embed-bitcode=no -C debuginfo=2 -C incremental=[REDACTED]

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack
```